### PR TITLE
added scope options under the strategy constructer documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -20,6 +20,8 @@ var util = require('util')
  *   - `clientID`      your Slack application's client id
  *   - `clientSecret`  your Slack application's client secret
  *   - `callbackURL`   URL to which Slack will redirect the user after granting authorization
+ *   - `scope`         array of permission scopes to request.  valid scopes include:
+ *                     'identify', 'read', 'post', 'client', or 'admin'.
  *
  * Examples:
  *
@@ -43,6 +45,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
+  options.scopeSeparator = options.scopeSeparator || ',';
   this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token=";
 
   OAuth2Strategy.call(this, options, verify);

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -28,7 +28,8 @@ var util = require('util')
  *     passport.use(new SlackStrategy({
  *         clientID: '123-456-789',
  *         clientSecret: 'shhh-its-a-secret'
- *         callbackURL: 'https://www.example.net/auth/slack/callback'
+ *         callbackURL: 'https://www.example.net/auth/slack/callback',
+ *         scope: 'identify,read,post,client,admin'
  *       },
  *       function(accessToken, refreshToken, profile, done) {
  *         User.findOrCreate(..., function (err, user) {


### PR DESCRIPTION
- added scope options under the documentation that's similar to [passport-github](https://github.com/jaredhanson/passport-github/blob/master/lib/strategy.js) 
- updated example with scope options
```
*     passport.use(new SlackStrategy({
 *         clientID: '123-456-789',
 *         clientSecret: 'shhh-its-a-secret'
 *         callbackURL: 'https://www.example.net/auth/slack/callback',
 *         scope: 'identify,read,post,client,admin'
 *       },
 *       function(accessToken, refreshToken, profile, done) {
 *         User.findOrCreate(..., function (err, user) {
 *           done(err, user);
 *         });
 *       }
 *     ));
```

