### PR TITLE
Adds support to specifiy a slack team to sign into

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -108,6 +108,24 @@ Strategy.prototype.get = function(url, access_token, callback) {
   this._oauth2._request("GET", url + access_token, {}, "", "", callback );
 };
 
+
+
+/**
+ * Return extra Slack parameters to be included in the authorization
+ * request.
+ *
+ * @param {Object} options
+ * @return {Object}
+ */
+Strategy.prototype.authorizationParams = function (options) {
+  var params = {};
+   if(options.team){
+     params.team = options.team;
+   }
+   console.log("params:" , params);
+  return params;
+};
+
 /**
  * Expose `Strategy`.
  */


### PR DESCRIPTION
For example the following line would force users to login to overtime.slack.com:
  app.get('/auth/slack', slack.passport.authenticate('slack', {'team': 'T07705ZPS'}));