### PR TITLE
Adding support to specify a team

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -120,7 +120,7 @@ Strategy.prototype.get = function(url, access_token, callback) {
  */
 Strategy.prototype.authorizationParams = function (options) {
   var params = {};
-  var team = options.team || _team;
+  var team = options.team || this._team;
    if(team){
      params.team = team;
    }

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -48,6 +48,7 @@ function Strategy(options, verify) {
   options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
   options.scopeSeparator = options.scopeSeparator || ',';
   this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token=";
+  this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'slack';
@@ -119,10 +120,10 @@ Strategy.prototype.get = function(url, access_token, callback) {
  */
 Strategy.prototype.authorizationParams = function (options) {
   var params = {};
-   if(options.team){
-     params.team = options.team;
+  var team = options.team || _team;
+   if(team){
+     params.team = team;
    }
-   console.log("params:" , params);
   return params;
 };
 

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -108,6 +108,24 @@ Strategy.prototype.get = function(url, access_token, callback) {
   this._oauth2._request("GET", url + access_token, {}, "", "", callback );
 };
 
+
+
+/**
+ * Return extra Slack parameters to be included in the authorization
+ * request.
+ *
+ * @param {Object} options
+ * @return {Object}
+ */
+Strategy.prototype.authorizationParams = function (options) {
+  var params = {};
+   if(options.team){
+     params.team = options.team;
+   }
+   console.log("params:" , params);
+  return params;
+};
+
 /**
  * Expose `Strategy`.
  */


### PR DESCRIPTION
This can be set when initializing SlackStrategy or when calling authenticate.
For example when initalizing SlackStrategy:
```javascript
passport.use(new SlackStrategy({
   clientID: '123-456-789', 
   clientSecret: 'shhh-its-a-secret'
   callbackURL: 'https://www.example.net/auth/slack/callback', 
   scope: 'identify,read,post,client,admin', 
   team: 'teamID' 
  }, function(accessToken, refreshToken, profile, done) { 
    User.findOrCreate(..., function (err, user) { 
       done(err, user); 
    }); 
  } 
));
```

or when calling authenticate /  authorize:
```javascript
app.get('/auth/slack', slack.passport.authenticate('slack', {'team': 'teamID'}));
```
