### PR TITLE
Use Slack's new oauth scopes

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -20,8 +20,9 @@ var util = require('util')
  *   - `clientID`      your Slack application's client id
  *   - `clientSecret`  your Slack application's client secret
  *   - `callbackURL`   URL to which Slack will redirect the user after granting authorization
- *   - `scope`         array of permission scopes to request.  valid scopes include:
- *                     'identify', 'read', 'post', 'client', or 'admin'.
+ *   - `scope`         array of permission scopes to request, for example:
+ *                     'identify', 'channels:read', 'chat:write:user', 'client', or 'admin'
+ *                     full set of scopes: https://api.slack.com/docs/oauth-scopes
  *
  * Examples:
  *
@@ -29,7 +30,7 @@ var util = require('util')
  *         clientID: '123-456-789',
  *         clientSecret: 'shhh-its-a-secret'
  *         callbackURL: 'https://www.example.net/auth/slack/callback',
- *         scope: 'identify,read,post,client,admin'
+ *         scope: 'identify channels:read chat:write:user client admin'
  *       },
  *       function(accessToken, refreshToken, profile, done) {
  *         User.findOrCreate(..., function (err, user) {
@@ -46,7 +47,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
-  options.scopeSeparator = options.scopeSeparator || ',';
+  options.scopeSeparator = options.scopeSeparator || ' ';
   this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token=";
   this.userInfoUrl = options.userInfoUrl || "https://slack.com/api/users.info?user=";
   this._team = options.team;


### PR DESCRIPTION
Update the comment header to use new slack OAuth scopes. `read` and `post` are deprecated. I've also changed the default separator to space since that's what slack prefers now: https://api.slack.com/docs/oauth