### PR TITLE
Skip users.info API call when users:read scope is not set

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -50,6 +50,7 @@ function Strategy(options, verify) {
   options.scopeSeparator = options.scopeSeparator || ' ';
   this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token=";
   this.userInfoUrl = options.userInfoUrl || "https://slack.com/api/users.info?user=";
+  this.skipuserInfo = options.scope.indexOf('users:read') === -1;
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
@@ -95,6 +96,10 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 
           profile._raw = body;
           profile._json = json;
+
+          if(self.skipuserInfo) {
+            return done(null, profile);
+          }
 
           self.get(self.userInfoUrl + profile.id + "&token=", accessToken, function (err, body, res) {
             if (err) {


### PR DESCRIPTION
It is possible to define your scopes such that calling the [users.info](https://api.slack.com/methods/users.info) API is not allowed. This will cause slack to throw a `missing_scope` error.

This skips the API call when the required `users:read` scope is missing.