### PR TITLE
Warn if scope users:read is not specified

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -48,12 +48,17 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
   options.scopeSeparator = options.scopeSeparator || ' ';
-  this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token=";
+  this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token="; // requires 'users:read' scope
   this.userInfoUrl = options.userInfoUrl || "https://slack.com/api/users.info?user=";
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
   this.name = options.name || 'slack';
+  
+  // warn is not enough scope
+  if(!this._skipUserProfile && this._scope.indexOf('users:read') === -1){
+    console.warn("Scope 'users:read' is required to retrieve Slack user profile");
+  }
 }
 
 /**


### PR DESCRIPTION
Continue from #11. Warn if scope not enough for getting user profile.