### PR TITLE
Include entire response from Slack when fetching user profile fails

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -107,7 +107,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
             }
             var infoJson = JSON.parse(body);
             if (!infoJson.ok) {
-              done(infoJson.error ? infoJson.error : body);
+              done(infoJson);
             }else{
               profile._json.info = infoJson;
               done(null, profile);

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -90,7 +90,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var json = JSON.parse(body);
 
         if (!json.ok) {
-          done(json.error ? json.error : body);
+          done(json);
         } else {
           var profile = {
             provider: 'Slack'


### PR DESCRIPTION
I stumbled upon this while investigating "missing_scope" error from Slack. It turned out that Slack returned more info (like "needed" scope) that was not propagated (only "error" part was). This one fixes it and passess entire Slack response back