### PR TITLE
Allow fetching only basic user profile without additional users:read scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ application:
       });
       
 #### Scopes
-By default passport-slack strategy will try to retrieve user profile from Slack. This requires `users:read` scope. To avoid getting profile, pass `skipUserProfile` option to strategy:
+By default passport-slack strategy will try to retrieve user profile from Slack. This requires `users:read` scope. To completely avoid getting profile, pass `skipUserProfile` option to strategy or if you just need basic user info, pass `extendedUserProfile: false` to strategy instead:
 ```javascript
 passport.use(new SlackStrategy({
 		clientID: settings.clientID,
@@ -57,13 +57,14 @@ passport.use(new SlackStrategy({
 	}, ()=>{})
 ```
 
-Or if you want to get profile:
+Or if you want to get basic profile:
 ```javascript
 passport.use(new SlackStrategy({
 		clientID: settings.clientID,
 		clientSecret: app.settings.clientSecret,
 		callbackURL: app.settings.callbackURL,
-		scope: 'incoming-webhook users:read'
+		scope: 'incoming-webhook users:read',
+    extendedUserProfile: false
 	}, ()=>{})
 ```
 

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -17,12 +17,14 @@ var util = require('util')
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `clientID`      your Slack application's client id
- *   - `clientSecret`  your Slack application's client secret
- *   - `callbackURL`   URL to which Slack will redirect the user after granting authorization
- *   - `scope`         array of permission scopes to request, for example:
- *                     'identify', 'channels:read', 'chat:write:user', 'client', or 'admin'
- *                     full set of scopes: https://api.slack.com/docs/oauth-scopes
+ *   - `clientID`               your Slack application's client id
+ *   - `clientSecret`           your Slack application's client secret
+ *   - `callbackURL`            URL to which Slack will redirect the user after granting authorization
+ *   - `scope`                  array of permission scopes to request, for example:
+ *                              'identify', 'channels:read', 'chat:write:user', 'client', or 'admin'
+ *                              full set of scopes: https://api.slack.com/docs/oauth-scopes
+ *   - `extendedUserProfile`    if set to false, only basic profile is fetched (does not require users:read scope)
+ *                              if set to true (default) complete profile is loaded
  *
  * Examples:
  *
@@ -48,15 +50,16 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
   options.scopeSeparator = options.scopeSeparator || ' ';
-  this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token="; // requires 'users:read' scope
-  this.userInfoUrl = options.userInfoUrl || "https://slack.com/api/users.info?user=";
+  this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token="; 
+  this.userInfoUrl = options.userInfoUrl || "https://slack.com/api/users.info?user="; // requires 'users:read' scope
+  this.extendedUserProfile = (options.extendedUserProfile == null) ? true : options.extendedUserProfile;
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
   this.name = options.name || 'slack';
-  
+
   // warn is not enough scope
-  if(!this._skipUserProfile && this._scope.indexOf('users:read') === -1){
+  if(!this._skipUserProfile && this.extendedUserProfile && this._scope.indexOf('users:read') === -1){
     console.warn("Scope 'users:read' is required to retrieve Slack user profile");
   }
 }
@@ -101,6 +104,11 @@ Strategy.prototype.userProfile = function(accessToken, done) {
           profile._raw = body;
           profile._json = json;
 
+          // if extended user profile is not required, return what we already have
+          if(!self.extendedUserProfile) {
+            return done(null, profile);
+          }
+          // otherwise call for more detailed profile (requires users:read scope)
           self.get(self.userInfoUrl + profile.id + "&token=", accessToken, function (err, body, res) {
             if (err) {
               return done(err);


### PR DESCRIPTION
Currently you can either fetch full profile (requires `users:read`) or don't fetch one at all (resulting with `profile` being `undefined` in auth callback).

This PR introduces new config option `extendedUserProfile` that if set to `false` allows fetching only basic user info (user id, team id, team name etc.) from `auth.test` endpoint. This way you can get this basic info in auth callback without granting additional `uses:read` permission.

For backward compatibility this option is set to `true` by default, which means it attempts to fetch this extended profile.