### PR TITLE
Added emails field on profile

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -118,6 +118,10 @@ Strategy.prototype.userProfile = function(accessToken, done) {
               done(infoJson);
             }else{
               profile._json.info = infoJson;
+              if (infoJson.user && infoJson.user.profile) {
+                profile.emails = [{ value: infoJson.user.profile.email }];
+              }
+              
               done(null, profile);
             }
           });


### PR DESCRIPTION
All the passport module return a field called emails that is an array of the email that the service comes back.
So I think that also this module should be on the same line with the passport standard.

You can find an example in the passport-facebook module 
https://github.com/jaredhanson/passport-facebook/blob/master/lib/profile.js#L24-L26