### PR TITLE
Updated to use Identity scopes with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [Passport](https://github.com/jaredhanson/passport) strategy for authenticating
 with [Slack](https://slack.com) using the OAuth 2.0 API.
 
+Updated to support Sign in with Slack by default.<br>
+[![Sign in with Slack](https://a.slack-edge.com/accd8/img/sign_in_with_slack.png)](https://api.slack.com/docs/sign-in-with-slack#identify_users_and_their_teams)
+
 ## Install
 ```shell
 $ npm install passport-slack
@@ -10,33 +13,35 @@ $ npm install passport-slack
 
 ## Express Example
 ```js
-const {CLIENT_ID, CLIENT_SECRET} = process.env,
+const {CLIENT_ID, CLIENT_SECRET, PORT} = process.env,
       SlackStrategy = require('passport-slack').Strategy,
       passport = require('passport'),
       express = require('express'),
       app = express();
 
-
+// setup the strategy using defaults 
 passport.use(new SlackStrategy({
     clientID: CLIENT_ID,
     clientSecret: CLIENT_SECRET
   }, (accessToken, refreshToken, profile, done) => {
+    // optionally persist profile data
     done(null, profile);
   }
 ));
 
-
-app.use(require('body-parser').urlencoded({ extended: true }));
 app.use(passport.initialize());
+app.use(require('body-parser').urlencoded({ extended: true }));
 
+// path to start the OAuth flow
 app.get('/auth/slack', passport.authorize('slack'));
 
+// OAuth callback url
 app.get('/auth/slack/callback', 
   passport.authorize('slack', { failureRedirect: '/login' }),
   (req, res) => res.redirect('/')
 );
 
-app.listen(3000);
+app.listen(PORT);
 ```
 
 ## Sample Profile

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -20,7 +20,7 @@ var util = require('util')
  *   - `clientID`               your Slack application's client id
  *   - `clientSecret`           your Slack application's client secret
  *   - `callbackURL`            URL to which Slack will redirect the user after granting authorization
- *   - `scopes`                 array of permission scopes to request defaults to: 
+ *   - `scope`                  array of permission scopes to request defaults to: 
  *                              ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team']
  *                              full set of scopes: https://api.slack.com/docs/oauth-scopes
  *

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -20,11 +20,9 @@ var util = require('util')
  *   - `clientID`               your Slack application's client id
  *   - `clientSecret`           your Slack application's client secret
  *   - `callbackURL`            URL to which Slack will redirect the user after granting authorization
- *   - `scope`                  array of permission scopes to request, for example:
- *                              'identify', 'channels:read', 'chat:write:user', 'client', or 'admin'
+ *   - `scopes`                 array of permission scopes to request defaults to: 
+ *                              ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team']
  *                              full set of scopes: https://api.slack.com/docs/oauth-scopes
- *   - `extendedUserProfile`    if set to false, only basic profile is fetched (does not require users:read scope)
- *                              if set to true (default) complete profile is loaded
  *
  * Examples:
  *
@@ -32,7 +30,7 @@ var util = require('util')
  *         clientID: '123-456-789',
  *         clientSecret: 'shhh-its-a-secret'
  *         callbackURL: 'https://www.example.net/auth/slack/callback',
- *         scope: 'identify channels:read chat:write:user client admin'
+ *         scope: ['identity.basic', 'channels:read', 'chat:write:user', 'client', 'admin']
  *       },
  *       function(accessToken, refreshToken, profile, done) {
  *         User.findOrCreate(..., function (err, user) {
@@ -47,20 +45,20 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://slack.com/api/oauth.access';
-  options.scopeSeparator = options.scopeSeparator || ' ';
-  this.profileUrl = options.profileUrl || "https://slack.com/api/auth.test?token="; 
-  this.userInfoUrl = options.userInfoUrl || "https://slack.com/api/users.info?user="; // requires 'users:read' scope
-  this.extendedUserProfile = (options.extendedUserProfile == null) ? true : options.extendedUserProfile;
+  options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
+  options.scope = options.scope || ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'];
+  
+  this.profileUrl = options.profileUrl || "https://slack.com/api/users.identity?token="; // requires 'identity.basic' scope
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);
   this.name = options.name || 'slack';
 
   // warn is not enough scope
-  if(!this._skipUserProfile && this.extendedUserProfile && this._scope.indexOf('users:read') === -1){
-    console.warn("Scope 'users:read' is required to retrieve Slack user profile");
+  // Details on Slack's identity scope - https://api.slack.com/methods/users.identity
+  if(!this._skipUserProfile && this._scope.indexOf('identity.basic') === -1){
+    console.warn("Scope 'identity.basic' is required to retrieve Slack user profile");
   }
 }
 
@@ -74,53 +72,32 @@ util.inherits(Strategy, OAuth2Strategy);
  *
  * This function constructs a normalized profile, with the following properties:
  *
- *   - `provider`         always set to `slack`
+ *   - `provider`         always set to `Slack`
  *   - `id`               the user's ID
- *   - `displayName`      the user's username
+ *   - `displayName`      the user's full name
  *
  * @param {String} accessToken
  * @param {Function} done
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  //this._oauth2.useAuthorizationHeaderforGET(true);
-  var self = this;
-  this.get(this.profileUrl, accessToken, function (err, body, res) {
+  this.get(this.profileUrl + accessToken, function (err, body, res) {
     if (err) {
       return done(err);
     } else {
       try {
-        var json = JSON.parse(body);
+        var profile = JSON.parse(body);
 
-        if (!json.ok) {
+        if (!profile.ok) {
           done(json);
         } else {
-          var profile = {
-            provider: 'Slack'
-          };
-          profile.id = json.user_id;
-          profile.displayName = json.user;
+          delete profile.ok;
 
-          profile._raw = body;
-          profile._json = json;
+          profile.provider = 'Slack';
+          profile.id = profile.user.id;
+          profile.displayName = profile.user.name;
 
-          // if extended user profile is not required, return what we already have
-          if(!self.extendedUserProfile) {
-            return done(null, profile);
-          }
-          // otherwise call for more detailed profile (requires users:read scope)
-          self.get(self.userInfoUrl + profile.id + "&token=", accessToken, function (err, body, res) {
-            if (err) {
-              return done(err);
-            }
-            var infoJson = JSON.parse(body);
-            if (!infoJson.ok) {
-              done(infoJson);
-            }else{
-              profile._json.info = infoJson;
-              done(null, profile);
-            }
-          });
+          done(null, profile);
         }
       } catch(e) {
         done(e);
@@ -132,8 +109,8 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 /** The default oauth2 strategy puts the access_token into Authorization: header AND query string
   * which is a violation of the RFC so lets override and not add the header and supply only the token for qs.
   */
-Strategy.prototype.get = function(url, access_token, callback) {
-  this._oauth2._request("GET", url + access_token, {}, "", "", callback );
+Strategy.prototype.get = function(url, callback) {
+  this._oauth2._request("GET", url, {}, "", "", callback );
 };
 
 
@@ -148,11 +125,13 @@ Strategy.prototype.get = function(url, access_token, callback) {
 Strategy.prototype.authorizationParams = function (options) {
   var params = {};
   var team = options.team || this._team;
-   if(team){
-     params.team = team;
-   }
+  if (team) {
+    params.team = team;
+  }
   return params;
 };
+
+
 
 /**
  * Expose `Strategy`.


### PR DESCRIPTION
This update replaces the recommendation for `users:read` in favor of Slack's `identity.*` scopes. The `users:read` scope allows access to all user data, while the `identity.*` scopes provides access to just the authenticated user.

These scopes were setup for [Sign in with Slack](https://api.slack.com/docs/sign-in-with-slack), but applies perfectly for passport.

I've also added a bit more documentation and examples.

Happy Thanksgiving 🦃 