### PR TITLE
use correct variable

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -89,7 +89,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var profile = JSON.parse(body);
 
         if (!profile.ok) {
-          done(json);
+          done(profile);
         } else {
           delete profile.ok;
 


### PR DESCRIPTION
Looks like this was an oversight that got missed with recent changes.