### PR TITLE
fix JSON error

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -89,7 +89,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var profile = JSON.parse(body);
 
         if (!profile.ok) {
-          done(json);
+          done(null, profile);
         } else {
           delete profile.ok;
 


### PR DESCRIPTION
This pull request was made in order to solve an issue. 
When slack authentication fails (in my case fails when I don't use 'identity.basic').

So when slack API returns a error `passport-slack` throws the following exception:

```bash
ReferenceError: json is not defined
   at /Users/vfernandes/project/node_modules/passport-slack/lib/passport-slack/strategy.js:92:16
   at passBackControl (/Users/vfernandes/project/node_modules/oauth/lib/oauth2.js:125:9)
   at IncomingMessage.<anonymous> (/Users/vfernandesproject/node_modules/oauth/lib/oauth2.js:143:7)
   at emitNone (events.js:91:20)
   at IncomingMessage.emit (events.js:185:7)
   at endReadableNT (_stream_readable.js:974:12)
   at _combinedTickCallback (internal/process/next_tick.js:74:11)
   at process._tickCallback (internal/process/next_tick.js:98:9)
```

The pull request #23, solves this issue but isn't the best way to do it. Because done callback doesn't return the error message.