### PR TITLE
Don't delete ok property from response

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -91,8 +91,6 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         if (!profile.ok) {
           done(json);
         } else {
-          delete profile.ok;
-
           profile.provider = 'Slack';
           profile.id = profile.user.id;
           profile.displayName = profile.user.name;


### PR DESCRIPTION
The `ok` property currently gets removed from successful responses, giving less flexibility for checking whether a response is successful or not.

The standard among passport strategies also seems to be to keep the `ok` property around, in both successful and unsuccessful responses.

This is a tiny tweak that won't cause any breakage, let me know what you think and if any additional edits would make sense before merging it in!