### PR TITLE
Add state param to options

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -89,7 +89,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var profile = JSON.parse(body);
 
         if (!profile.ok) {
-          done(json);
+          done(body);
         } else {
           delete profile.ok;
 

--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -128,6 +128,11 @@ Strategy.prototype.authorizationParams = function (options) {
   if (team) {
     params.team = team;
   }
+
+  if (options.state) {
+    params.state = options.state
+  }
+
   return params;
 };
 


### PR DESCRIPTION
Slack has an option for the state param to be passed at the beginning of ouath and is then given back as a url param on the callback.

This provided to be useful for a project I was working on and should be in the core version of this package. 