### PR TITLE
Fix: ReferenceError

### DIFF
--- a/lib/passport-slack/strategy.js
+++ b/lib/passport-slack/strategy.js
@@ -89,7 +89,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         var profile = JSON.parse(body);
 
         if (!profile.ok) {
-          done(json);
+          done(profile);
         } else {
           delete profile.ok;
 


### PR DESCRIPTION
return the whole `profile` as the error passed to `done` and not `json` which is not defined and caused a ReferenceError in the catch